### PR TITLE
Ignore the xml declaration line

### DIFF
--- a/src/lib/license-manager.ts
+++ b/src/lib/license-manager.ts
@@ -141,7 +141,7 @@ export class LicenseManager {
             }).join(EOL);
         }
 
-        if (fileContents.startsWith('#!')) {
+        if (fileContents.startsWith('#!') || fileContents.startsWith('<?xml')) {
             const lines = fileContents.split(/\r?\n/);
 
             newText = lines[0] + EOL + formattedLicense;


### PR DESCRIPTION
Like for the bash shebang (`#!`), a valid xml file must start with `<?xml ?>`.